### PR TITLE
Added missing include sys/types.h for pid_t

### DIFF
--- a/src/include/MultiProcessing.h
+++ b/src/include/MultiProcessing.h
@@ -44,6 +44,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdlib.h>
 #include <unistd.h> 
 #include <sys/wait.h>
+#include <sys/types.h>
 
 /**
  * \brief Alias for MultiProcess function run mutants.


### PR DESCRIPTION
I found that include statement is missing on my brand-new Fedora 13
